### PR TITLE
feat: ランナーバージョン自動更新とビルド競合防止

### DIFF
--- a/spawn-runners-docker.sh
+++ b/spawn-runners-docker.sh
@@ -108,8 +108,8 @@ build_image() {
     while ! mkdir "$LOCK_DIR" 2>/dev/null; do
         local lock_pid
         lock_pid=$(cat "$LOCK_DIR/pid" 2>/dev/null || echo "")
-        if [ -n "$lock_pid" ] && ! kill -0 "$lock_pid" 2>/dev/null; then
-            echo "Stale lock detected (PID $lock_pid), removing..."
+        if [ -z "$lock_pid" ] || ! kill -0 "$lock_pid" 2>/dev/null; then
+            echo "Stale lock detected (PID ${lock_pid:-none}), removing..."
             rm -rf "$LOCK_DIR"
             continue
         fi
@@ -129,6 +129,7 @@ build_image() {
         if ! docker build --build-arg RUNNER_VERSION="$CURRENT_RUNNER_VERSION" -t "$tag" "$SCRIPT_DIR/docker/"; then
             echo "Error: Failed to build runner image"
             release_lock
+            trap cleanup SIGINT SIGTERM
             return 1
         fi
     fi
@@ -256,7 +257,7 @@ while true; do
 
     # Rebuild image if version changed; running containers finish naturally
     # and will be respawned with the new image below
-    check_version_update
+    check_version_update || true
 
     for i in $(seq 1 "$COUNT"); do
         name=$(container_name "$i")


### PR DESCRIPTION
## Summary
- 5分ごとにGitHub APIで最新ランナーバージョンをチェックし、変更時にイメージを自動再ビルド
- バージョンタグ付きイメージ (`gh-runner:x.y.z`) で複数プロセス並列実行時の競合を防止
- `mkdir` ロック + ダブルチェックで同時ビルドを排他制御
- 実行中のジョブは中断せず、完了後に新イメージで respawn

## Test plan
- [ ] 単一プロセスでスクリプトを起動し、バージョンチェックログが5分後に出ることを確認
- [ ] 同一リポジトリで2プロセス並列起動し、ビルドが重複しないことを確認
- [ ] 異なるリポジトリで並列起動し、イメージタグが共有されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically updates the GitHub Actions runner image on upstream releases and prevents duplicate builds in parallel runs. Uses versioned tags so containers respawn cleanly; requires `gh` for release checks.

- **New Features**
  - Checks every 5 minutes via `gh api`; rebuilds only on version change and tags images as `gh-runner:x.y.z`.
  - Keeps current jobs running; exited containers respawn with the new image.
  - Prevents duplicate builds with an atomic `mkdir` lock and double-check; skips if the versioned image already exists.

- **Bug Fixes**
  - Prevents the monitor loop from exiting under `set -e`; reliably releases locks on failures and signals.
  - Detects and clears stale locks even without a PID file; restores traps after build failures to avoid stuck locks.
  - Only switches to a new version after a successful build; reverts to the previous version on failure.

<sup>Written for commit 8c4b70cc25301ea1ff3219b2239a3642c1eac3fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 定期的にGitHubの最新ランナーバージョンを確認し、自動で新バージョンに更新します

* **改善**
  * ランナー用Dockerイメージをバージョン別に管理し、不要な再ビルドを回避します
  * 同時実行時のビルド競合を防止します
  * 既存ジョブを優先して終了させた上で新バージョンのランナーに切り替えます
<!-- end of auto-generated comment: release notes by coderabbit.ai -->