### PR TITLE
fix: chownループで内部ファイルの所有者もチェックする

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,8 +16,9 @@ log() {
 cd /home/runner
 
 # Fix ownership of volume mount points (may be root-owned on first creation)
+# Checks files inside too — the parent may be runner-owned while internal files remain root-owned
 for dir in /home/runner/.npm /home/runner/pw-browsers; do
-    if [ -d "$dir" ] && [ "$(stat -c '%u' "$dir" 2>/dev/null)" != "$(id -u)" ]; then
+    if [ -d "$dir" ] && sudo find "$dir" -maxdepth 2 ! -user runner -print -quit 2>/dev/null | grep -q .; then
         if ! sudo chown -R runner:runner "$dir"; then
             log "WARNING: Failed to fix ownership of $dir"
         fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,7 +18,7 @@ cd /home/runner
 # Fix ownership of volume mount points (may be root-owned on first creation)
 # Checks files inside too — the parent may be runner-owned while internal files remain root-owned
 for dir in /home/runner/.npm /home/runner/pw-browsers; do
-    if [ -d "$dir" ] && sudo find "$dir" -maxdepth 2 ! -user runner -print -quit 2>/dev/null | grep -q .; then
+    if [ -d "$dir" ] && [ -n "$(sudo find "$dir" ! -user runner -print -quit 2>/dev/null)" ]; then
         if ! sudo chown -R runner:runner "$dir"; then
             log "WARNING: Failed to fix ownership of $dir"
         fi


### PR DESCRIPTION
## Summary
- chown ループの所有者チェックを `stat -c '%u'`（ディレクトリ自体のみ）から `find -maxdepth 2 ! -user runner`（内部ファイルも検出）に変更
- 親ディレクトリが runner 所有でも内部ファイルが root 所有のケースで chown がスキップされる問題を修正

## Background
Docker ボリュームの特性上、親ディレクトリは runner 所有だが内部ファイルだけが root 所有という状態が発生する。従来の `stat` チェックではこのケースを見逃し、`chown -R` が実行されないため後続ジョブでパーミッションエラーが発生する可能性があった。

Closes #11

## Test plan
- [ ] Docker イメージを再ビルドして変更が反映されることを確認
- [ ] runner 所有ディレクトリ内に root 所有ファイルがある場合に chown が実行されることを確認
- [ ] ディレクトリが存在しない場合にエラーなく通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code) (session: d2067ac6-7553-471d-ba38-e1c33760f356)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ownership checks in the Docker entrypoint to detect root-owned files at any depth inside volume directories and trigger `chown` when needed. Prevents permission errors when the parent is runner-owned but nested files are not.

- **Bug Fixes**
  - Replace `stat` with `sudo find "$dir" ! -user runner -print -quit` to scan all levels and exit fast; use command substitution with `test -n` to avoid pipefail/SIGPIPE false negatives.
  - Run `chown -R runner:runner` only when such files exist, ensuring needed fixes on first-time mounts.

<sup>Written for commit cd4cc894202a0619200a1e08767f02bd8f134a45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア (Chores)**
  * Docker コンテナの初期化処理を改善しました。ディレクトリ内のファイルの所有権を更に正確に検出できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->