### PR TITLE
fix: busyなofflineランナーのジョブをキャンセルして強制削除

### DIFF
--- a/cleanup-runners.sh
+++ b/cleanup-runners.sh
@@ -62,9 +62,10 @@ if ! gh auth status &> /dev/null; then
     exit 1
 fi
 
-# Get offline runners (include busy status)
+# Get offline runners (include busy status; tab-delimited to avoid issues with | in names)
+TAB=$'\t'
 if ! OFFLINE_RUNNERS=$(gh api --paginate "/repos/$REPO/actions/runners?per_page=100" \
-    --jq '.runners[] | select(.status == "offline") | "\(.id)|\(.name)|\(.busy)"'); then
+    --jq '.runners[] | select(.status == "offline") | "\(.id)\t\(.name)\t\(.busy)"'); then
     echo "Error: Failed to fetch runners for $REPO." >&2
     exit 1
 fi
@@ -75,11 +76,11 @@ else
     # Separate idle and busy runners
     IDLE_RUNNERS=""
     BUSY_RUNNERS=""
-    while IFS='|' read -r id name busy; do
+    while IFS="$TAB" read -r id name busy; do
         if [ "$busy" = "true" ]; then
-            BUSY_RUNNERS="${BUSY_RUNNERS}${id}|${name}"$'\n'
+            BUSY_RUNNERS="${BUSY_RUNNERS}${id}${TAB}${name}"$'\n'
         else
-            IDLE_RUNNERS="${IDLE_RUNNERS}${id}|${name}"$'\n'
+            IDLE_RUNNERS="${IDLE_RUNNERS}${id}${TAB}${name}"$'\n'
         fi
     done <<< "$OFFLINE_RUNNERS"
     IDLE_RUNNERS="${IDLE_RUNNERS%$'\n'}"
@@ -88,7 +89,7 @@ else
     # Handle idle runners
     if [ -n "$IDLE_RUNNERS" ]; then
         echo "Found offline runners:"
-        while IFS='|' read -r id name; do
+        while IFS="$TAB" read -r id name; do
             echo "  - $name (ID: $id)"
         done <<< "$IDLE_RUNNERS"
         echo ""
@@ -99,7 +100,7 @@ else
         if [[ $REPLY =~ ^[Yy]$ ]]; then
             echo ""
             echo "Removing..."
-            while IFS='|' read -r id name; do
+            while IFS="$TAB" read -r id name; do
                 echo "  Removing $name..."
                 gh api --method DELETE "/repos/$REPO/actions/runners/$id" 2>/dev/null \
                     || echo "    Failed to remove $name"
@@ -114,7 +115,7 @@ else
     # Handle busy runners (offline but marked as running a job = likely hung)
     if [ -n "$BUSY_RUNNERS" ]; then
         echo "Found offline runners stuck in busy state (likely hung):"
-        while IFS='|' read -r id name; do
+        while IFS="$TAB" read -r id name; do
             echo "  - $name (ID: $id)"
         done <<< "$BUSY_RUNNERS"
         echo ""
@@ -131,7 +132,7 @@ else
 
             # Build runner ID set for lookup
             BUSY_IDS=""
-            while IFS='|' read -r id name; do
+            while IFS="$TAB" read -r id name; do
                 BUSY_IDS="${BUSY_IDS} ${id} "
             done <<< "$BUSY_RUNNERS"
 
@@ -166,7 +167,7 @@ else
 
             # Remove runners with retry (cancellation is asynchronous)
             echo "Removing runners..."
-            while IFS='|' read -r id name; do
+            while IFS="$TAB" read -r id name; do
                 removed=false
                 for attempt in 1 2 3; do
                     if gh api --method DELETE "/repos/$REPO/actions/runners/$id" 2>/dev/null; then
@@ -208,7 +209,7 @@ if [ "$CLEANUP_VOLUMES" = true ]; then
     found_volumes=()
     for vol in "$NPM_VOL" "$PW_VOL"; do
         if docker volume inspect "$vol" &>/dev/null; then
-            size=$(docker system df -v 2>/dev/null | grep "^$vol " | awk '{print $3 $4}')
+            size=$(docker system df -v 2>/dev/null | grep -F "$vol " | awk '{print $3 $4}')
             found_volumes+=("$vol")
             echo "  $vol (${size:-size unknown})"
         fi

--- a/cleanup-runners.sh
+++ b/cleanup-runners.sh
@@ -62,34 +62,115 @@ if ! gh auth status &> /dev/null; then
     exit 1
 fi
 
-# Get offline runners
-OFFLINE_RUNNERS=$(gh api "/repos/$REPO/actions/runners" --jq '.runners[] | select(.status == "offline") | "\(.id)|\(.name)"' 2>/dev/null)
+# Get offline runners (include busy status)
+OFFLINE_RUNNERS=$(gh api "/repos/$REPO/actions/runners" \
+    --jq '.runners[] | select(.status == "offline") | "\(.id)|\(.name)|\(.busy)"' 2>/dev/null)
 
 if [ -z "$OFFLINE_RUNNERS" ]; then
     echo "No offline runners found."
 else
-    echo "Found offline runners:"
-    echo "$OFFLINE_RUNNERS" | while IFS='|' read -r id name; do
-        echo "  - $name (ID: $id)"
-    done
-    echo ""
+    # Separate idle and busy runners
+    IDLE_RUNNERS=""
+    BUSY_RUNNERS=""
+    while IFS='|' read -r id name busy; do
+        if [ "$busy" = "true" ]; then
+            BUSY_RUNNERS="${BUSY_RUNNERS}${id}|${name}"$'\n'
+        else
+            IDLE_RUNNERS="${IDLE_RUNNERS}${id}|${name}"$'\n'
+        fi
+    done <<< "$OFFLINE_RUNNERS"
+    IDLE_RUNNERS="${IDLE_RUNNERS%$'\n'}"
+    BUSY_RUNNERS="${BUSY_RUNNERS%$'\n'}"
 
-    # Confirm
-    read -p "Remove these runners from GitHub? [y/N] " -n 1 -r
-    echo ""
+    # Handle idle runners
+    if [ -n "$IDLE_RUNNERS" ]; then
+        echo "Found offline runners:"
+        while IFS='|' read -r id name; do
+            echo "  - $name (ID: $id)"
+        done <<< "$IDLE_RUNNERS"
+        echo ""
 
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        read -p "Remove these runners from GitHub? [y/N] " -n 1 -r
         echo ""
-        echo "Removing..."
 
-        echo "$OFFLINE_RUNNERS" | while IFS='|' read -r id name; do
-            echo "  Removing $name..."
-            gh api --method DELETE "/repos/$REPO/actions/runners/$id" 2>/dev/null || echo "    Failed to remove $name"
-        done
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            echo ""
+            echo "Removing..."
+            while IFS='|' read -r id name; do
+                echo "  Removing $name..."
+                gh api --method DELETE "/repos/$REPO/actions/runners/$id" 2>/dev/null \
+                    || echo "    Failed to remove $name"
+            done <<< "$IDLE_RUNNERS"
+            echo ""
+        else
+            echo "Skipped runner removal."
+            echo ""
+        fi
+    fi
+
+    # Handle busy runners (offline but marked as running a job = likely hung)
+    if [ -n "$BUSY_RUNNERS" ]; then
+        echo "Found offline runners stuck in busy state (likely hung):"
+        while IFS='|' read -r id name; do
+            echo "  - $name (ID: $id)"
+        done <<< "$BUSY_RUNNERS"
         echo ""
-    else
-        echo "Skipped runner removal."
+        echo "These runners are offline but GitHub thinks they are running a job."
+        echo "Their associated workflow runs must be cancelled before removal."
         echo ""
+
+        read -r -t 0.1 _ 2>/dev/null || true
+        read -p "Cancel associated runs and remove these runners? [y/N] " -n 1 -r
+        echo ""
+
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            echo ""
+
+            # Build runner ID set for lookup
+            BUSY_IDS=""
+            while IFS='|' read -r id name; do
+                BUSY_IDS="${BUSY_IDS} ${id} "
+            done <<< "$BUSY_RUNNERS"
+
+            # Find and cancel workflow runs on these runners
+            echo "Cancelling associated workflow runs..."
+            IN_PROGRESS_RUNS=$(gh api "/repos/$REPO/actions/runs?status=in_progress&per_page=100" \
+                --jq '.workflow_runs[].id' 2>/dev/null)
+
+            if [ -n "$IN_PROGRESS_RUNS" ]; then
+                while read -r run_id; do
+                    # Check if any job in this run is assigned to a busy runner
+                    MATCHED_RUNNER=$(gh api "/repos/$REPO/actions/runs/$run_id/jobs?filter=latest&per_page=100" \
+                        --jq "[.jobs[] | select(.runner_id != null) | .runner_id] | .[]" 2>/dev/null)
+
+                    for runner_id in $MATCHED_RUNNER; do
+                        if [[ "$BUSY_IDS" == *" ${runner_id} "* ]]; then
+                            echo "  Cancelling run $run_id..."
+                            gh api --method POST \
+                                "/repos/$REPO/actions/runs/$run_id/cancel" 2>/dev/null \
+                                || echo "    Failed to cancel run $run_id"
+                            break
+                        fi
+                    done
+                done <<< "$IN_PROGRESS_RUNS"
+            fi
+
+            # Wait for cancellation to propagate
+            echo "  Waiting for cancellations to propagate..."
+            sleep 3
+
+            # Now remove the runners
+            echo "Removing runners..."
+            while IFS='|' read -r id name; do
+                echo "  Removing $name..."
+                gh api --method DELETE "/repos/$REPO/actions/runners/$id" 2>/dev/null \
+                    || echo "    Failed to remove $name (run may still be cancelling, retry later)"
+            done <<< "$BUSY_RUNNERS"
+            echo ""
+        else
+            echo "Skipped busy runner removal."
+            echo ""
+        fi
     fi
 fi
 

--- a/cleanup-runners.sh
+++ b/cleanup-runners.sh
@@ -137,14 +137,20 @@ else
 
             # Find and cancel workflow runs on these runners
             echo "Cancelling associated workflow runs..."
-            IN_PROGRESS_RUNS=$(gh api --paginate "/repos/$REPO/actions/runs?status=in_progress&per_page=100" \
-                --jq '.workflow_runs[].id' 2>/dev/null)
+            if ! IN_PROGRESS_RUNS=$(gh api --paginate "/repos/$REPO/actions/runs?status=in_progress&per_page=100" \
+                --jq '.workflow_runs[].id' 2>/dev/null); then
+                echo "  Warning: Failed to fetch in-progress runs, skipping cancellation"
+                IN_PROGRESS_RUNS=""
+            fi
 
             if [ -n "$IN_PROGRESS_RUNS" ]; then
                 while read -r run_id; do
-                    # Check if any job in this run is assigned to a busy runner
-                    MATCHED_RUNNER=$(gh api --paginate "/repos/$REPO/actions/runs/$run_id/jobs?filter=latest&per_page=100" \
-                        --jq "[.jobs[] | select(.status == \"in_progress\" and .runner_id != null) | .runner_id] | .[]" 2>/dev/null)
+                    # Check if any in-progress job in this run is assigned to a busy runner
+                    if ! MATCHED_RUNNER=$(gh api --paginate "/repos/$REPO/actions/runs/$run_id/jobs?filter=latest&per_page=100" \
+                        --jq "[.jobs[] | select(.status == \"in_progress\" and .runner_id != null) | .runner_id] | .[]" 2>/dev/null); then
+                        echo "  Warning: Failed to fetch jobs for run $run_id, skipping"
+                        continue
+                    fi
 
                     for runner_id in $MATCHED_RUNNER; do
                         if [[ "$BUSY_IDS" == *" ${runner_id} "* ]]; then
@@ -158,16 +164,25 @@ else
                 done <<< "$IN_PROGRESS_RUNS"
             fi
 
-            # Wait for cancellation to propagate
-            echo "  Waiting for cancellations to propagate..."
-            sleep 3
-
-            # Now remove the runners
+            # Remove runners with retry (cancellation is asynchronous)
             echo "Removing runners..."
             while IFS='|' read -r id name; do
-                echo "  Removing $name..."
-                gh api --method DELETE "/repos/$REPO/actions/runners/$id" 2>/dev/null \
-                    || echo "    Failed to remove $name (run may still be cancelling, retry later)"
+                removed=false
+                for attempt in 1 2 3; do
+                    if gh api --method DELETE "/repos/$REPO/actions/runners/$id" 2>/dev/null; then
+                        removed=true
+                        break
+                    fi
+                    if [ "$attempt" -lt 3 ]; then
+                        echo "    Retrying removal of $name ($attempt/3)..."
+                        sleep 3
+                    fi
+                done
+                if [ "$removed" = true ]; then
+                    echo "  Removed $name"
+                else
+                    echo "    Failed to remove $name after 3 attempts (retry later)"
+                fi
             done <<< "$BUSY_RUNNERS"
             echo ""
         else

--- a/cleanup-runners.sh
+++ b/cleanup-runners.sh
@@ -63,8 +63,11 @@ if ! gh auth status &> /dev/null; then
 fi
 
 # Get offline runners (include busy status)
-OFFLINE_RUNNERS=$(gh api "/repos/$REPO/actions/runners" \
-    --jq '.runners[] | select(.status == "offline") | "\(.id)|\(.name)|\(.busy)"' 2>/dev/null)
+if ! OFFLINE_RUNNERS=$(gh api --paginate "/repos/$REPO/actions/runners?per_page=100" \
+    --jq '.runners[] | select(.status == "offline") | "\(.id)|\(.name)|\(.busy)"'); then
+    echo "Error: Failed to fetch runners for $REPO." >&2
+    exit 1
+fi
 
 if [ -z "$OFFLINE_RUNNERS" ]; then
     echo "No offline runners found."
@@ -119,7 +122,7 @@ else
         echo "Their associated workflow runs must be cancelled before removal."
         echo ""
 
-        read -r -t 0.1 _ 2>/dev/null || true
+        while IFS= read -r -t 0 -n 1 _ 2>/dev/null; do :; done
         read -p "Cancel associated runs and remove these runners? [y/N] " -n 1 -r
         echo ""
 
@@ -134,14 +137,14 @@ else
 
             # Find and cancel workflow runs on these runners
             echo "Cancelling associated workflow runs..."
-            IN_PROGRESS_RUNS=$(gh api "/repos/$REPO/actions/runs?status=in_progress&per_page=100" \
+            IN_PROGRESS_RUNS=$(gh api --paginate "/repos/$REPO/actions/runs?status=in_progress&per_page=100" \
                 --jq '.workflow_runs[].id' 2>/dev/null)
 
             if [ -n "$IN_PROGRESS_RUNS" ]; then
                 while read -r run_id; do
                     # Check if any job in this run is assigned to a busy runner
-                    MATCHED_RUNNER=$(gh api "/repos/$REPO/actions/runs/$run_id/jobs?filter=latest&per_page=100" \
-                        --jq "[.jobs[] | select(.runner_id != null) | .runner_id] | .[]" 2>/dev/null)
+                    MATCHED_RUNNER=$(gh api --paginate "/repos/$REPO/actions/runs/$run_id/jobs?filter=latest&per_page=100" \
+                        --jq "[.jobs[] | select(.status == \"in_progress\" and .runner_id != null) | .runner_id] | .[]" 2>/dev/null)
 
                     for runner_id in $MATCHED_RUNNER; do
                         if [[ "$BUSY_IDS" == *" ${runner_id} "* ]]; then
@@ -200,7 +203,7 @@ if [ "$CLEANUP_VOLUMES" = true ]; then
         echo "No cache volumes found for $REPO."
     else
         echo ""
-        read -r -t 0.1 _ 2>/dev/null || true
+        while IFS= read -r -t 0 -n 1 _ 2>/dev/null; do :; done
         read -p "Remove these volumes? [y/N] " -n 1 -r
         echo ""
 


### PR DESCRIPTION
## Summary
- offlineかつbusyなランナー（ハング状態）を削除できるようにした
- 関連するworkflow runを特定・キャンセルしてからランナーを削除する
- idle/busyを分離表示し、それぞれ対話プロンプトで確認する

## Test plan
- [ ] offline + idle なランナーのみ存在する場合、従来通り削除できること
- [ ] offline + busy なランナーが存在する場合、キャンセル→削除のフローが動作すること
- [ ] offline ランナーがない場合のメッセージ表示

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force-remove offline-but-busy GitHub Actions runners by cancelling their in-progress runs, then deleting with retries. Also split offline runners into idle and busy lists with separate confirmations in `cleanup-runners.sh`.

- **Bug Fixes**
  - Detect offline+busy; paginate runners/runs/jobs; match only `in_progress` jobs by `runner_id`; cancel runs, then delete with up to 3 retries to avoid 422.
  - Handle transient `gh api` failures without aborting under `set -e`; warn and continue; show a clear message when no offline runners exist.
  - Keep normal deletion flow for offline+idle; separate lists and prompts; bash 3.2–compatible input buffer clearing; tab-delimited parsing to avoid `|` in names; use `grep -F` for volume name matching.

<sup>Written for commit ab3c4ec726faaecbe55a973036f5eb1bd427fcc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ランナー検出に実行状態フラグを追加
  * アイドルランナーと処理中ランナーを分別して管理
  * 処理中ランナーの削除時に進行中のワークフローを自動キャンセル
  * ランナー削除フローの最適化と確認プロンプトの改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->