### PR TITLE
fix: runner イメージに GitHub CLI (gh) を追加する

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,13 +18,14 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
     && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# gh is absent from the Ubuntu repos, and workflows driving issues/PRs need it
+# noble universe pins gh at 2.45.0, so take the latest from the official apt repo.
+# The suite qualifier keeps a missing repo loud instead of silently installing that 2.45.0
 RUN curl -fsSL -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
         https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
         > /etc/apt/sources.list.d/github-cli.list \
-    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && apt-get update && apt-get install -y --no-install-recommends gh/stable \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m runner \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,15 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
     && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# gh is absent from the Ubuntu repos, and workflows driving issues/PRs need it
+RUN curl -fsSL -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+        https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN useradd -m runner \
     && echo "runner ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 


### PR DESCRIPTION
## Summary

self-hosted runner の Docker イメージに GitHub CLI (gh) を追加する。

runner イメージ (Ubuntu 24.04 ベース) には `curl` / `jq` / `git` / `shellcheck` / `nodejs` は入っていたが `gh` だけが無く、gh を使う workflow が `gh: command not found` で失敗していた。Ubuntu noble の universe にも `gh 2.45.0-1ubuntu0.3` はあるが版が固定されるため、公式 apt リポジトリを追加して最新を入れる。

## 変更

- `docker/Dockerfile`: nodejs ブロックと `useradd` の間に gh の apt リポジトリ追加 + インストールを挿入（root 権限が要るため `USER runner` より前に置く）
- apt の arch は `dpkg --print-architecture` から取得する。`TARGETARCH` は actions/runner の tarball 名 (`x64` / `arm64`) へ変換するために宣言されている一方、apt が使う arch 表記は dpkg のものと同一のため
- インストールは `gh/stable` と suite を明示する。`ubuntu:24.04` は universe を既定で有効にしているため、無指定だと GitHub 側 repo を引けなかったときに universe の 2.45.0 が黙って入り build が緑のまま通る

## 検証

ローカル (linux/arm64) で実施:

- `DOCKER_BUILDKIT=1 docker build --build-arg RUNNER_VERSION=2.336.0 docker/` が成功。`Get:1 https://cli.github.com/packages stable/main arm64 gh arm64 2.97.0` を解決している
- `gh --version` → `gh version 2.97.0 (2026-07-31)`、`dpkg -s gh` → `Maintainer: GitHub` / `Version: 2.97.0`（`USER runner` の PATH で実行可能）
- 既存ツールの回帰なし: `node v22.23.2` / `git 2.43.0` / `jq-1.7` / `shellcheck 0.9.0`、実行ユーザーは `runner`
- amd64 も `--platform linux/amd64` の `--no-cache` build で `dpkg --print-architecture` が `amd64` を返し、`gh amd64 2.97.0` の取得・インストールに成功
- silent fallback の実証（GitHub 側 repo を足さない素の `ubuntu:24.04` で比較）:
  - `apt-get install -y --no-install-recommends gh` → **成功**し `noble-updates/universe` の `2.45.0-1ubuntu0.3` が入る（build は緑のまま）
  - `apt-get install -y --no-install-recommends gh/stable` → `E: Release 'stable' for 'gh' was not found` / exit 100 で **build 失敗**

## 反映方法

`spawn-runners-docker.sh` は起動のたびに `docker build` を実行する設計（`build_image()` 冒頭のコメント参照）のため、merge 後に spawner を Ctrl+C で停止して再実行すれば、layer cache により差分のみ再ビルドされて反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs GitHub CLI (`gh`) in the self-hosted runner image so workflows using `gh` stop failing. Previously the image lacked `gh`; now it installs `gh` from the official GitHub CLI `apt` repository, adding the signed repo and keyring.

- Modifies `docker/Dockerfile` only: adds the GitHub CLI keyring and repo, installs `gh`, and cleans `apt` lists.
- Derives the `apt` architecture via `dpkg --print-architecture` (independent of `TARGETARCH`).
- Runs the install before creating the `runner` user so it executes with root; `gh` is available on the `runner` PATH.

**Rollout**
- Rebuild the image to apply: stop the spawner and run `spawn-runners-docker.sh` again. No workflow changes required.

<sup>Written for commit d31c1bf85bdc34d2ba8c096fff70cdbf183d2437. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/silenvx/github-runner-spawner/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>